### PR TITLE
Update the TXN_SPIKE behaviour to match new specifications

### DIFF
--- a/src/Microemulsion/Microemulsion.cpp
+++ b/src/Microemulsion/Microemulsion.cpp
@@ -725,16 +725,49 @@ void Microemulsion::setTranscriptionInhibitionOnChains(const std::set<ChainId> &
     }
 }
 
-void Microemulsion::enableTranscribabilityOnChains(std::set<ChainId> targetChains)
+void Microemulsion::enablePermissivityOnChains(std::set<ChainId> targetChains)
 {
     logger.logMsg(PRODUCTION, "Transcription enabled on %d chains", targetChains.size());
     setTranscriptionInhibitionOnChains(targetChains, TRANSCRIPTION_POSSIBLE);
 }
 
-void Microemulsion::disableTranscribabilityOnChains(std::set<ChainId> targetChains)
+void Microemulsion::disablePermissivityOnChains(std::set<ChainId> targetChains)
 {
     logger.logMsg(PRODUCTION, "Transcription inhibited on %d chains", targetChains.size());
     setTranscriptionInhibitionOnChains(targetChains, TRANSCRIPTION_INHIBITED);
+}
+
+void Microemulsion::setTranscribabilityOnChains(const std::set<ChainId> &targetChains,
+                                                       const Transcribability &transcribability) const
+{
+    for (int row = grid.getFirstRow(); row <= grid.getLastRow(); ++row)
+    {
+        for (int column = grid.getFirstColumn(); column <= grid.getLastColumn(); ++column)
+        {
+            CellData &curCell = grid.getElement(column, row);
+            std::set<ChainId> curCellChains = curCell.chainsCellBelongsTo();
+            std::set<ChainId> matches;
+            set_intersection(curCellChains.begin(), curCellChains.end(),
+                             targetChains.begin(), targetChains.end(),
+                             inserter(matches, matches.begin()));
+            if (!matches.empty())
+            {
+                curCell.setTranscribability(transcribability);
+            }
+        }
+    }
+}
+
+void Microemulsion::enableTranscribabilityOnChains(std::set<ChainId> targetChains)
+{
+    logger.logMsg(PRODUCTION, "Transcribable state enabled on %d chains", targetChains.size());
+    setTranscribabilityOnChains(targetChains, TRANSCRIBABLE);
+}
+
+void Microemulsion::disableTranscribabilityOnChains(std::set<ChainId> targetChains)
+{
+    logger.logMsg(PRODUCTION, "Transcribable state disabled on %d chains", targetChains.size());
+    setTranscribabilityOnChains(targetChains, NOT_TRANSCRIBABLE);
 }
 
 bool Microemulsion::isSwapBlockedByStickyBoundary(int x, int y, int nx, int ny)

--- a/src/Microemulsion/Microemulsion.h
+++ b/src/Microemulsion/Microemulsion.h
@@ -76,12 +76,19 @@ public:
      * Switch the given chain to the transcribable state.
      * @param targetChains
      */
+    void enablePermissivityOnChains(std::set<ChainId> targetChains);
+    
+    void disablePermissivityOnChains(std::set<ChainId> targetChains);
+    
+    void
+    setTranscriptionInhibitionOnChains(const std::set<ChainId> &targetChains, const TranscriptionInhibition &inhibition) const;
+    
     void enableTranscribabilityOnChains(std::set<ChainId> targetChains);
     
     void disableTranscribabilityOnChains(std::set<ChainId> targetChains);
     
     void
-    setTranscriptionInhibitionOnChains(const std::set<ChainId> &targetChains, const TranscriptionInhibition &inhibition) const;
+    setTranscribabilityOnChains(const std::set<ChainId> &targetChains, const Transcribability &transcribability) const;
 
 private:
     double computePartialDifferentialEnergy(int x, int y, int nx, int ny);


### PR DESCRIPTION
The TXN_SPIKE event now just switch all the permissible chromatin to the TRANSCRIBABLE state, without any change in the rates. This means it has to be paired with an ACTIVATE event. Please note that if ACTIVATE and TXN_SPIKE are scheduled at the same time, they are commutative, i.e. it does not matter which one is executed first.

Closes #19